### PR TITLE
Support systems without clock_gettime()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,8 @@ AX_PTHREAD([
 ])
 
 AC_SEARCH_LIBS([clock_gettime], [rt])
+AC_CHECK_FUNCS([clock_gettime])
+
 AC_SEARCH_LIBS([socket], [socket])
 
 AC_CHECK_DECLS([fread_unlocked, fwrite_unlocked, fflush_unlocked])

--- a/fstrm/fstrm-private.h
+++ b/fstrm/fstrm-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ * Copyright (c) 2013-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@
 #include "libmy/my_alloc.h"
 #include "libmy/my_memory_barrier.h"
 #include "libmy/my_queue.h"
+#include "libmy/my_time.h"
 #include "libmy/read_bytes.h"
 #include "libmy/vector.h"
 
@@ -162,6 +163,7 @@ fstrm__rdwr_write_control(struct fstrm_rdwr *,
 
 /* time */
 
+#if HAVE_CLOCK_GETTIME
 bool fstrm__get_best_monotonic_clock_gettime(clockid_t *);
 
 bool fstrm__get_best_monotonic_clock_pthread(clockid_t *);
@@ -169,8 +171,7 @@ bool fstrm__get_best_monotonic_clock_pthread(clockid_t *);
 bool fstrm__get_best_monotonic_clocks(clockid_t *clkid_gettime,
 				      clockid_t *clkid_pthread,
 				      char **errstr_out);
-
-int fstrm__pthread_cond_timedwait(clockid_t, pthread_cond_t *, pthread_mutex_t *, unsigned);
+#endif
 
 /* queue */
 

--- a/fstrm/time.c
+++ b/fstrm/time.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ * Copyright (c) 2013-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 #include "fstrm-private.h"
+
+#if HAVE_CLOCK_GETTIME
 
 bool
 fstrm__get_best_monotonic_clock_pthread(clockid_t *c)
@@ -125,19 +127,4 @@ fstrm__get_best_monotonic_clocks(clockid_t *clkid_gettime,
 	return true;
 }
 
-int
-fstrm__pthread_cond_timedwait(clockid_t clock_id,
-			      pthread_cond_t *cond,
-			      pthread_mutex_t *mutex,
-			      unsigned seconds)
-{
-	int res;
-	struct timespec ts;
-	res = clock_gettime(clock_id, &ts);
-	assert(res == 0);
-	ts.tv_sec += seconds;
-	pthread_mutex_lock(mutex);
-	res = pthread_cond_timedwait(cond, mutex, &ts);
-	pthread_mutex_unlock(mutex);
-	return res;
-}
+#endif /* HAVE_CLOCK_GETTIME */

--- a/t/test_fstrm_io_file.c
+++ b/t/test_fstrm_io_file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ * Copyright (c) 2013-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -272,7 +272,13 @@ main(int argc, char **argv)
 		assert(0); /* not reached */
 	}
 
-	my_gettime(CLOCK_MONOTONIC, &ts_a);
+#if HAVE_CLOCK_GETTIME
+	const clockid_t clock = CLOCK_MONOTONIC;
+#else
+	const int clock = -1;
+#endif
+	my_gettime(clock, &ts_a);
+
 
 	printf("creating %u producer threads\n", num_threads);
 	for (unsigned i = 0; i < num_threads; i++)
@@ -285,7 +291,7 @@ main(int argc, char **argv)
 	printf("destroying fstrm_iothr object\n");
 	fstrm_iothr_destroy(&iothr);
 
-	my_gettime(CLOCK_MONOTONIC, &ts_b);
+	my_gettime(clock, &ts_b);
 	my_timespec_sub(&ts_a, &ts_b);
 	elapsed = my_timespec_to_double(&ts_b);
 	printf("completed in %.2f seconds\n", elapsed);

--- a/t/test_fstrm_io_unix.c
+++ b/t/test_fstrm_io_unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ * Copyright (c) 2013-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -443,7 +443,12 @@ main(int argc, char **argv)
 		assert(0); /* not reached */
 	}
 
-	my_gettime(CLOCK_MONOTONIC, &ts_a);
+#if HAVE_CLOCK_GETTIME
+	const clockid_t clock = CLOCK_MONOTONIC;
+#else
+	const int clock = -1;
+#endif
+	my_gettime(clock, &ts_a);
 
 	printf("creating %u producer threads\n", num_threads);
 	for (unsigned i = 0; i < num_threads; i++)
@@ -459,7 +464,7 @@ main(int argc, char **argv)
 	printf("joining consumer thread\n");
 	pthread_join(test_consumer.thr, (void **) NULL);
 
-	my_gettime(CLOCK_MONOTONIC, &ts_b);
+	my_gettime(clock, &ts_b);
 	my_timespec_sub(&ts_a, &ts_b);
 	elapsed = my_timespec_to_double(&ts_b);
 	printf("completed in %.2f seconds\n", elapsed);

--- a/t/test_queue.c
+++ b/t/test_queue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ * Copyright (c) 2013-2016 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,7 +235,12 @@ run_test(void)
 	pthread_t thr_p;
 	pthread_t thr_c;
 
-	my_gettime(CLOCK_MONOTONIC, &ts_a);
+#if HAVE_CLOCK_GETTIME
+	const clockid_t clock = CLOCK_MONOTONIC;
+#else
+	const int clock = -1;
+#endif
+	my_gettime(clock, &ts_a);
 
 	pthread_create(&thr_p, NULL, thr_producer, NULL);
 	pthread_create(&thr_c, NULL, thr_consumer, NULL);
@@ -247,7 +252,7 @@ run_test(void)
 	send_shutdown_message(q);
 	pthread_join(thr_c, (void **) &cs);
 
-	my_gettime(CLOCK_MONOTONIC, &ts_b);
+	my_gettime(clock, &ts_b);
 
 	res = check_stats(ps, cs);
 	print_stats(&ts_a, &ts_b, ps, cs);


### PR DESCRIPTION
This branch adds OS X compatibility. I haven't personally tested it on an Apple machine, but it compiles and the test suite passes in the Travis-CI OS X environment.