### PR TITLE
TCP support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,7 @@ nobase_include_HEADERS = \
 	fstrm/file.h		\
 	fstrm/rdwr.h		\
 	fstrm/reader.h		\
+	fstrm/tcp_writer.h	\
 	fstrm/unix_writer.h	\
 	fstrm/writer.h
 
@@ -59,6 +60,7 @@ fstrm_libfstrm_la_SOURCES = \
 	fstrm/iothr.c fstrm/iothr.h		\
 	fstrm/rdwr.c fstrm/rdwr.h		\
 	fstrm/reader.c fstrm/reader.h		\
+	fstrm/tcp_writer.c fstrm/tcp_writer.h	\
 	fstrm/time.c				\
 	fstrm/unix_writer.c fstrm/unix_writer.h	\
 	fstrm/writer.c fstrm/writer.h		\

--- a/Makefile.am
+++ b/Makefile.am
@@ -136,19 +136,24 @@ t/run_test_fstrm_io_file.sh: t/test_fstrm_io_file
 TESTS += t/run_test_fstrm_io_file.sh
 EXTRA_DIST += t/run_test_fstrm_io_file.sh
 
-check_PROGRAMS += t/test_fstrm_io_unix
-t_test_fstrm_io_unix_SOURCES = \
-	t/test_fstrm_io_unix.c \
+check_PROGRAMS += t/test_fstrm_io_sock
+t_test_fstrm_io_sock_SOURCES = \
+	t/test_fstrm_io_sock.c \
 	libmy/my_alloc.h \
 	libmy/my_time.h \
 	libmy/print_string.h \
 	libmy/ubuf.h \
 	libmy/vector.h
-t_test_fstrm_io_unix_LDADD = \
+t_test_fstrm_io_sock_LDADD = \
 	fstrm/libfstrm.la
-t/run_test_fstrm_io_unix.sh: t/test_fstrm_io_unix
+
+t/run_test_fstrm_io_unix.sh: t/test_fstrm_io_sock
 TESTS += t/run_test_fstrm_io_unix.sh
 EXTRA_DIST += t/run_test_fstrm_io_unix.sh
+
+t/run_test_fstrm_io_tcp.sh: t/test_fstrm_io_sock
+TESTS += t/run_test_fstrm_io_tcp.sh
+EXTRA_DIST += t/run_test_fstrm_io_tcp.sh
 
 check_PROGRAMS += t/test_writer_hello
 t_test_writer_hello_SOURCES = \

--- a/fstrm/fstrm.h
+++ b/fstrm/fstrm.h
@@ -285,6 +285,7 @@ struct fstrm_writer_options;
 #include <fstrm/iothr.h>
 #include <fstrm/rdwr.h>
 #include <fstrm/reader.h>
+#include <fstrm/tcp_writer.h>
 #include <fstrm/unix_writer.h>
 #include <fstrm/writer.h>
 

--- a/fstrm/libfstrm.sym
+++ b/fstrm/libfstrm.sym
@@ -73,3 +73,12 @@ global:
 local:
         *;
 };
+
+LIBFSTRM_0.4.0 {
+global:
+        fstrm_tcp_writer_options_init;
+        fstrm_tcp_writer_options_destroy;
+        fstrm_tcp_writer_options_set_socket_address;
+        fstrm_tcp_writer_options_set_socket_port;
+        fstrm_tcp_writer_init;
+} LIBFSTRM_0.2.0;

--- a/fstrm/tcp_writer.c
+++ b/fstrm/tcp_writer.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2013-2014 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "fstrm-private.h"
+
+struct fstrm_tcp_writer_options {
+	char			*socket_address;
+	char			*socket_port;
+};
+
+struct fstrm__tcp_writer {
+	bool			connected;
+	int			fd;
+	struct sockaddr_storage	ss;
+};
+
+struct fstrm_tcp_writer_options *
+fstrm_tcp_writer_options_init(void)
+{
+	return my_calloc(1, sizeof(struct fstrm_tcp_writer_options));
+}
+
+void
+fstrm_tcp_writer_options_destroy(struct fstrm_tcp_writer_options **twopt)
+{
+	if (*twopt != NULL) {
+		my_free((*twopt)->socket_address);
+		my_free((*twopt)->socket_port);
+		my_free(*twopt);
+	}
+}
+
+void
+fstrm_tcp_writer_options_set_socket_address(
+	struct fstrm_tcp_writer_options *twopt,
+	const char *socket_address)
+{
+	my_free(twopt->socket_address);
+	if (socket_address != NULL)
+		twopt->socket_address = my_strdup(socket_address);
+}
+
+void
+fstrm_tcp_writer_options_set_socket_port(
+	struct fstrm_tcp_writer_options *twopt,
+	const char *socket_port)
+{
+	my_free(twopt->socket_port);
+	if (socket_port != NULL)
+		twopt->socket_port = my_strdup(socket_port);
+}
+
+static fstrm_res
+fstrm__tcp_writer_op_open(void *obj)
+{
+	struct fstrm__tcp_writer *w = obj;
+
+	/* Nothing to do if the socket is already connected. */
+	if (w->connected)
+		return fstrm_res_success;
+
+	/* Open an Internet socket. Request socket close-on-exec if available. */
+#if defined(SOCK_CLOEXEC)
+	w->fd = socket(w->ss.ss_family, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	if (w->fd < 0 && errno == EINVAL)
+		w->fd = socket(w->ss.ss_family, SOCK_STREAM, 0);
+#else
+	w->fd = socket(w->ss.ss_family, SOCK_STREAM, 0);
+#endif
+	if (w->fd < 0)
+		return fstrm_res_failure;
+
+	/*
+	 * Request close-on-exec if available. There is nothing that can be done
+	 * if the F_SETFD call to fcntl() fails, so don't bother checking the
+	 * return value.
+	 *
+	 * https://lwn.net/Articles/412131/
+	 * [ Ghosts of Unix past, part 2: Conflated designs ]
+	 */
+#if defined(FD_CLOEXEC)
+	int flags = fcntl(w->fd, F_GETFD, 0);
+	if (flags != -1) {
+		flags |= FD_CLOEXEC;
+		(void) fcntl(w->fd, F_SETFD, flags);
+	}
+#endif
+
+#if defined(SO_NOSIGPIPE)
+	/*
+	 * Ugh, no signals, please!
+	 *
+	 * https://lwn.net/Articles/414618/
+	 * [ Ghosts of Unix past, part 3: Unfixable designs ]
+	 */
+	static const int on = 1;
+	if (setsockopt(w->fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on)) != 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+#endif
+
+	/* Connect the AF_UNIX socket. */
+	if (connect(w->fd, (struct sockaddr *) &w->ss, sizeof(w->ss)) < 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+
+	w->connected = true;
+	return fstrm_res_success;
+}
+
+static fstrm_res
+fstrm__tcp_writer_op_close(void *obj)
+{
+	struct fstrm__tcp_writer *w = obj;
+	if (w->connected) {
+		w->connected = false;
+		if (close(w->fd) != 0)
+			return fstrm_res_failure;
+		return fstrm_res_success;
+	}
+	return fstrm_res_failure;
+}
+
+static fstrm_res
+fstrm__tcp_writer_op_read(void *obj, void *buf, size_t nbytes)
+{
+	struct fstrm__tcp_writer *w = obj;
+	if (likely(w->connected)) {
+		if (read_bytes(w->fd, buf, nbytes))
+			return fstrm_res_success;
+	}
+	return fstrm_res_failure;
+}
+
+static fstrm_res
+fstrm__tcp_writer_op_write(void *obj, const struct iovec *iov, int iovcnt)
+{
+	struct fstrm__tcp_writer *w = obj;
+
+	size_t nbytes = 0;
+	ssize_t written = 0;
+	int cur = 0;
+	struct msghdr msg = {
+		.msg_iov = (struct iovec *) /* Grr! */ iov,
+		.msg_iovlen = iovcnt,
+	};
+
+	if (unlikely(!w->connected))
+		return fstrm_res_failure;
+
+	for (int i = 0; i < iovcnt; i++)
+		nbytes += iov[i].iov_len;
+
+	for (;;) {
+		do {
+			written = sendmsg(w->fd, &msg, MSG_NOSIGNAL);
+		} while (written == -1 && errno == EINTR);
+		if (written == -1)
+			return fstrm_res_failure;
+		if (cur == 0 && written == (ssize_t) nbytes)
+			return fstrm_res_success;
+
+		while (written >= (ssize_t) msg.msg_iov[cur].iov_len)
+		       written -= msg.msg_iov[cur++].iov_len;
+
+		if (cur == iovcnt)
+			return fstrm_res_success;
+
+		msg.msg_iov[cur].iov_base = (void *)
+			((char *) msg.msg_iov[cur].iov_base + written);
+		msg.msg_iov[cur].iov_len -= written;
+	}
+}
+
+static fstrm_res
+fstrm__tcp_writer_op_destroy(void *obj)
+{
+	struct fstrm__tcp_writer *w = obj;
+	my_free(w);
+	return fstrm_res_success;
+}
+
+static fstrm_res
+fstrm__tcp_writer_fill_socket_port(struct fstrm__tcp_writer *w,
+				   const struct fstrm_tcp_writer_options *twopt)
+{
+	uint64_t port = 0;
+	char *endptr = NULL;
+
+	port = strtoul(twopt->socket_port, &endptr, 0);
+	if (*endptr != '\0' || port > UINT16_MAX) {
+		return fstrm_res_failure;
+	}
+
+	if (w->ss.ss_family == AF_INET) {
+		struct sockaddr_in *sai = (struct sockaddr_in *) &w->ss;
+		sai->sin_port = htons(port);
+		return fstrm_res_success;
+	} else if (w->ss.ss_family == AF_INET6) {
+		struct sockaddr_in6 *sai6 = (struct sockaddr_in6 *) &w->ss;
+		sai6->sin6_port = htons(port);
+		return fstrm_res_success;
+	}
+
+	return fstrm_res_failure;
+}
+
+static fstrm_res
+fstrm__tcp_writer_fill_socket_address(struct fstrm__tcp_writer *w,
+				      const struct fstrm_tcp_writer_options *twopt)
+{
+	struct sockaddr_in *sai = (struct sockaddr_in *) &w->ss;
+	struct sockaddr_in6 *sai6 = (struct sockaddr_in6 *) &w->ss;
+
+	if (inet_pton(AF_INET, twopt->socket_address, &sai->sin_addr) == 1) {
+		w->ss.ss_family = AF_INET;
+		return fstrm_res_success;
+	} else if (inet_pton(AF_INET6, twopt->socket_address, &sai6->sin6_addr) == 1) {
+		w->ss.ss_family = AF_INET6;
+		return fstrm_res_success;
+	}
+
+	return fstrm_res_failure;
+}
+
+struct fstrm_writer *
+fstrm_tcp_writer_init(const struct fstrm_tcp_writer_options *twopt,
+		       const struct fstrm_writer_options *wopt)
+{
+	struct fstrm_rdwr *rdwr;
+	struct fstrm__tcp_writer *tw;
+
+	if (twopt->socket_address == NULL || twopt->socket_port == NULL)
+		return NULL;
+
+	tw = my_calloc(1, sizeof(*tw));
+
+	if (!(fstrm__tcp_writer_fill_socket_address(tw, twopt) == fstrm_res_success &&
+	      fstrm__tcp_writer_fill_socket_port(tw, twopt) == fstrm_res_success))
+	{
+		my_free(tw);
+		return NULL;
+	}
+
+	rdwr = fstrm_rdwr_init(tw);
+	fstrm_rdwr_set_destroy(rdwr, fstrm__tcp_writer_op_destroy);
+	fstrm_rdwr_set_open(rdwr, fstrm__tcp_writer_op_open);
+	fstrm_rdwr_set_close(rdwr, fstrm__tcp_writer_op_close);
+	fstrm_rdwr_set_read(rdwr, fstrm__tcp_writer_op_read);
+	fstrm_rdwr_set_write(rdwr, fstrm__tcp_writer_op_write);
+	return fstrm_writer_init(wopt, &rdwr);
+}

--- a/fstrm/tcp_writer.h
+++ b/fstrm/tcp_writer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FSTRM_TCP_WRITER_H
+#define FSTRM_TCP_WRITER_H
+
+/**
+ * \defgroup fstrm_tcp_writer fstrm_tcp_writer
+ *
+ * `fstrm_tcp_writer` is an interface for opening an \ref fstrm_writer object
+ * that is backed by I/O on a TCP socket.
+ *
+ * @{
+ */
+
+/**
+ * Initialize an `fstrm_tcp_writer_options` object, which is needed to
+ * configure the socket address and socket port to be opened by the writer.
+ *
+ * \return
+ *	`fstrm_tcp_writer_options` object.
+ */
+struct fstrm_tcp_writer_options *
+fstrm_tcp_writer_options_init(void);
+
+/**
+ * Destroy an `fstrm_tcp_writer_options` object.
+ *
+ * \param twopt
+ *	Pointer to `fstrm_tcp_writer_options` object.
+ */
+void
+fstrm_tcp_writer_options_destroy(
+	struct fstrm_tcp_writer_options **twopt);
+
+/**
+ * Set the `socket_address` option. This is the IPv4 or IPv6 address in
+ * presentation format to be connected by the TCP socket.
+ *
+ * \param twopt
+ *	`fstrm_tcp_writer_options` object.
+ * \param socket_address
+ *	The socket address.
+ */
+void
+fstrm_tcp_writer_options_set_socket_address(
+	struct fstrm_tcp_writer_options *twopt,
+	const char *socket_address);
+
+/**
+ * Set the `socket_port` option. This is the TCP port number to be connected by
+ * the TCP socket.
+ *
+ * \param twopt
+ *	`fstrm_tcp_writer_options` object.
+ * \param socket_address
+ *	The socket address.
+ */
+void
+fstrm_tcp_writer_options_set_socket_port(
+	struct fstrm_tcp_writer_options *twopt,
+	const char *socket_port);
+
+/**
+ * Initialize the `fstrm_writer` object. Note that the TCP socket will not
+ * actually be opened until a subsequent call to fstrm_writer_open().
+ *
+ * \param twopt
+ *	`fstrm_tcp_writer_options` object. Must be non-NULL, and have the
+ *	`socket_address` and `socket_port` options set.
+ * \param wopt
+ *	`fstrm_writer_options` object. May be NULL, in which chase default
+ *	values will be used.
+ *
+ * \return
+ *	`fstrm_writer` object.
+ * \retval
+ *	NULL on failure.
+ */
+struct fstrm_writer *
+fstrm_tcp_writer_init(
+	const struct fstrm_tcp_writer_options *twopt,
+	const struct fstrm_writer_options *wopt);
+
+/**@}*/
+
+#endif /* FSTRM_TCP_WRITER_H */

--- a/fstrm/writer.h
+++ b/fstrm/writer.h
@@ -28,7 +28,8 @@
  *
  * Some basic `fstrm_writer` implementations are already provided in the `fstrm`
  * library. See fstrm_file_writer_init() for an implementation that writes to
- * a regular file and fstrm_unix_writer_init() for an implementation that writes
+ * a regular file, fstrm_tcp_writer_init() for an implementation that writes to
+ * a TCP socket, and fstrm_unix_writer_init() for an implementation that writes
  * to a Unix socket.
  *
  * @{

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,6 +1,6 @@
 test_control
 test_file_hello
 test_fstrm_io_file
-test_fstrm_io_unix
+test_fstrm_io_sock
 test_queue
 test_writer_hello

--- a/t/run_test_fstrm_io_tcp.sh
+++ b/t/run_test_fstrm_io_tcp.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-TNAME="test_fstrm_io_sock unix"
-SOCKNAME="./test.sock"
+TNAME="test_fstrm_io_sock tcp"
+SOCKADDR="127.0.0.1"
 
 if [ -z "$DIRNAME" ]; then
     DIRNAME="$(dirname $(readlink -f $0))"
@@ -10,9 +10,7 @@ fi
 for QUEUE_MODEL in SPSC MPSC; do
     for NUM_THREADS in 1 4 16; do
         for NUM_MESSAGES in 1 1000 100000; do
-            $DIRNAME/$TNAME "$SOCKNAME" $QUEUE_MODEL $NUM_THREADS $NUM_MESSAGES
+            $DIRNAME/$TNAME $SOCKADDR $QUEUE_MODEL $NUM_THREADS $NUM_MESSAGES
         done
     done
 done
-
-rm -f "$SOCKNAME"

--- a/t/test_fstrm_io_sock.c
+++ b/t/test_fstrm_io_sock.c
@@ -308,7 +308,7 @@ thr_consumer(void *arg)
 }
 
 static int
-get_server_socket(const char *socket_path)
+get_unix_server_socket(const char *socket_path)
 {
 	struct sockaddr_un sa;
 	int sfd;
@@ -341,30 +341,93 @@ get_server_socket(const char *socket_path)
 	return sfd;
 }
 
+static int
+get_tcp_server_socket(const char *socket_address, uint16_t *socket_port)
+{
+	struct sockaddr_storage ss = {0};
+	struct sockaddr_in *sai = (struct sockaddr_in *) &ss;
+	struct sockaddr_in6 *sai6 = (struct sockaddr_in6 *) &ss;
+	int sfd;
+
+	if (inet_pton(AF_INET, socket_address, &sai->sin_addr) == 1) {
+		ss.ss_family = AF_INET;
+	} else if (inet_pton(AF_INET6, socket_address, &sai6->sin6_addr) == 1) {
+		ss.ss_family = AF_INET6;
+	} else {
+		perror("inet_pton");
+		abort();
+	}
+
+	sfd = socket(ss.ss_family, SOCK_STREAM, 0);
+	if (sfd == -1) {
+		perror("socket");
+		abort();
+	}
+
+	if (bind(sfd, (struct sockaddr *) &ss, sizeof(ss)) == -1) {
+		perror("bind");
+		abort();
+	}
+
+	if (listen(sfd, 1) == -1) {
+		perror("listen");
+		abort();
+	}
+
+	if (socket_port != NULL) {
+		socklen_t len_ss = sizeof(ss);
+		if (getsockname(sfd, (struct sockaddr *) &ss, &len_ss) == -1) {
+			perror("getsockname");
+			abort();
+		}
+		if (ss.ss_family == AF_INET) {
+			*socket_port = ntohs(sai->sin_port);
+		} else if (ss.ss_family == AF_INET6) {
+			*socket_port = ntohs(sai6->sin6_port);
+		} else {
+			perror("getsockname");
+			abort();
+		}
+	}
+
+	return sfd;
+}
+
 int
 main(int argc, char **argv)
 {
 	struct timespec ts_a, ts_b;
 	double elapsed;
-	char *socket_path;
+	char *socket_type;
+	char *socket_param;
 	char *queue_model_str;
 	unsigned num_messages;
 	unsigned num_threads;
+	char *unix_socket_path;
+	char *tcp_socket_address;
+	uint16_t tcp_socket_port;
+	char s_tcp_socket_port[16] = {0};
 	fstrm_iothr_queue_model queue_model;
+	bool is_unix;
 
-	if (argc != 5) {
-		fprintf(stderr, "Usage: %s <SOCKET> <QUEUE MODEL> <NUM THREADS> <NUM MESSAGES>\n", argv[0]);
+	if (argc != 6) {
+		fprintf(stderr, "Usage: %s <SOCKET TYPE> <SOCKET PARAM> <QUEUE MODEL> <NUM THREADS> <NUM MESSAGES>\n", argv[0]);
 		fprintf(stderr, "\n");
-		fprintf(stderr, "SOCKET is a filesystem path.\n");
+		fprintf(stderr, "SOCKET TYPE is 'tcp' or 'unix'.");
+		fprintf(stderr, "For SOCKET TYPE 'unix', SOCKET PARAMS should be a filesystem path.");
+		fprintf(stderr, "For SOCKET TYPE 'tcp', SOCKET PARAMS should be a socket address.");
 		fprintf(stderr, "QUEUE MODEL is the string 'SPSC' or 'MPSC'.\n");
 		fprintf(stderr, "NUM THREADS is an integer.\n");
 		fprintf(stderr, "NUM MESSAGES is an integer.\n");
+		fprintf(stderr, "\n");
 		return EXIT_FAILURE;
 	}
-	socket_path = argv[1];
-	queue_model_str = argv[2];
-	num_threads = atoi(argv[3]);
-	num_messages = atoi(argv[4]);
+	socket_type = argv[1];
+	socket_param = argv[2];
+	queue_model_str = argv[3];
+	num_threads = atoi(argv[4]);
+	num_messages = atoi(argv[5]);
+
 	if (num_threads < 1) {
 		fprintf(stderr, "%s: Error: invalid number of threads\n", argv[0]);
 		return EXIT_FAILURE;
@@ -383,21 +446,55 @@ main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if (strcasecmp(socket_type, "unix") == 0) {
+		unix_socket_path = socket_param;
+		is_unix = true;
+	} else if (strcasecmp(socket_type, "tcp") == 0) {
+		tcp_socket_address = socket_param;
+		is_unix = false;
+	} else {
+		fprintf(stderr, "%s: Error: invalid SOCKET TYPE specified", argv[0]);
+		return EXIT_FAILURE;
+	}
+
 	printf("setting up 300 second timeout\n");
 	alarm(300);
 
-	printf("testing fstrm_iothr with socket= %s "
+	printf("testing fstrm_iothr with socket param %s "
 	       "queue_model= %s "
 	       "num_threads= %u "
 	       "num_messages= %u\n",
-	       socket_path, queue_model_str, num_threads, num_messages);
+	       socket_param, queue_model_str, num_threads, num_messages);
 
-	struct fstrm_unix_writer_options *uwopt;
-	uwopt = fstrm_unix_writer_options_init();
-	fstrm_unix_writer_options_set_socket_path(uwopt, socket_path);
-	struct fstrm_writer *w = fstrm_unix_writer_init(uwopt, NULL);
+	struct consumer test_consumer;
+	if (is_unix) {
+		printf("opening unix server socket on %s\n", unix_socket_path);
+		test_consumer.server_fd = get_unix_server_socket(unix_socket_path);
+	} else {
+		printf("opening tcp server socket on %s\n", tcp_socket_address);
+		test_consumer.server_fd = get_tcp_server_socket(tcp_socket_address, &tcp_socket_port);
+		snprintf(s_tcp_socket_port, sizeof(s_tcp_socket_port), "%u", tcp_socket_port);
+	}
+
+	struct fstrm_writer *w = NULL;
+
+	if (is_unix) {
+		struct fstrm_unix_writer_options *uwopt;
+		uwopt = fstrm_unix_writer_options_init();
+		fstrm_unix_writer_options_set_socket_path(uwopt, unix_socket_path);
+		w = fstrm_unix_writer_init(uwopt, NULL);
+		assert(w != NULL);
+		fstrm_unix_writer_options_destroy(&uwopt);
+	} else {
+		struct fstrm_tcp_writer_options *twopt;
+		twopt = fstrm_tcp_writer_options_init();
+		fstrm_tcp_writer_options_set_socket_address(twopt, tcp_socket_address);
+		fstrm_tcp_writer_options_set_socket_port(twopt, s_tcp_socket_port);
+		w = fstrm_tcp_writer_init(twopt, NULL);
+		assert(w != NULL);
+		fstrm_tcp_writer_options_destroy(&twopt);
+	}
 	assert(w != NULL);
-	fstrm_unix_writer_options_destroy(&uwopt);
 
 	struct fstrm_iothr_options *iothr_opt;
 	iothr_opt = fstrm_iothr_options_init();
@@ -410,10 +507,6 @@ main(int argc, char **argv)
 		assert(0); /* not reached */
 	}
 	fstrm_iothr_options_set_queue_model(iothr_opt, queue_model);
-
-	struct consumer test_consumer;
-	printf("opening server socket on %s\n", socket_path);
-	test_consumer.server_fd = get_server_socket(socket_path);
 
 	printf("creating consumer thread\n");
 	pthread_create(&test_consumer.thr, NULL, thr_consumer, &test_consumer);


### PR DESCRIPTION
This branch implements a `tcp_writer` (similar to the existing `unix_writer`) in the core library and adds TCP support to `fstrm_capture` and the test suite.

(Fixes #20.)