### PR TITLE
Fix tcp addrlen

### DIFF
--- a/fstrm/tcp_writer.c
+++ b/fstrm/tcp_writer.c
@@ -32,6 +32,7 @@ struct fstrm__tcp_writer {
 	bool			connected;
 	int			fd;
 	struct sockaddr_storage	ss;
+	socklen_t		ss_len;
 };
 
 struct fstrm_tcp_writer_options *
@@ -121,7 +122,7 @@ fstrm__tcp_writer_op_open(void *obj)
 #endif
 
 	/* Connect the TCP socket. */
-	if (connect(w->fd, (struct sockaddr *) &w->ss, sizeof(w->ss)) < 0) {
+	if (connect(w->fd, (struct sockaddr *) &w->ss, w->ss_len) < 0) {
 		close(w->fd);
 		return fstrm_res_failure;
 	}
@@ -236,9 +237,11 @@ fstrm__tcp_writer_fill_socket_address(struct fstrm__tcp_writer *w,
 
 	if (inet_pton(AF_INET, twopt->socket_address, &sai->sin_addr) == 1) {
 		w->ss.ss_family = AF_INET;
+		w->ss_len = sizeof(*sai);
 		return fstrm_res_success;
 	} else if (inet_pton(AF_INET6, twopt->socket_address, &sai6->sin6_addr) == 1) {
 		w->ss.ss_family = AF_INET6;
+		w->ss_len = sizeof(*sai6);
 		return fstrm_res_success;
 	}
 

--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -15,6 +15,7 @@
  */
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/t/test_fstrm_io_sock.c
+++ b/t/test_fstrm_io_sock.c
@@ -348,12 +348,15 @@ get_tcp_server_socket(const char *socket_address, uint16_t *socket_port)
 	struct sockaddr_storage ss = {0};
 	struct sockaddr_in *sai = (struct sockaddr_in *) &ss;
 	struct sockaddr_in6 *sai6 = (struct sockaddr_in6 *) &ss;
+	socklen_t ss_len = sizeof(ss);
 	int sfd;
 
 	if (inet_pton(AF_INET, socket_address, &sai->sin_addr) == 1) {
 		ss.ss_family = AF_INET;
+		ss_len = sizeof(*sai);
 	} else if (inet_pton(AF_INET6, socket_address, &sai6->sin6_addr) == 1) {
 		ss.ss_family = AF_INET6;
+		ss_len = sizeof(*sai6);
 	} else {
 		perror("inet_pton");
 		abort();
@@ -365,7 +368,7 @@ get_tcp_server_socket(const char *socket_address, uint16_t *socket_port)
 		abort();
 	}
 
-	if (bind(sfd, (struct sockaddr *) &ss, sizeof(ss)) == -1) {
+	if (bind(sfd, (struct sockaddr *) &ss, ss_len) == -1) {
 		perror("bind");
 		abort();
 	}
@@ -376,8 +379,7 @@ get_tcp_server_socket(const char *socket_address, uint16_t *socket_port)
 	}
 
 	if (socket_port != NULL) {
-		socklen_t len_ss = sizeof(ss);
-		if (getsockname(sfd, (struct sockaddr *) &ss, &len_ss) == -1) {
+		if (getsockname(sfd, (struct sockaddr *) &ss, &ss_len) == -1) {
 			perror("getsockname");
 			abort();
 		}

--- a/t/test_fstrm_io_sock.c
+++ b/t/test_fstrm_io_sock.c
@@ -15,6 +15,7 @@
  */
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>


### PR DESCRIPTION
Some BSD-derived systems appear to require a correct `addrlen` parameter to `bind()` and `connect()` system calls, and will fail with `EINVAL` when given `sizeof(struct sockaddr_storage)`.  This PR calculates and stores the correct address length when the corresponding address structure is filled in, for use at `bind()` and `connect()`.