### PR TITLE
Branches/capture buffer concurrency

### DIFF
--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -166,17 +166,17 @@ static argv_t g_args[] = {
 		"<PORT>",
 		"TCP socket port to read from" },
 
-	{ 'b',	"buffer_size",
+	{ 'b',	"buffersize",
 		ARGV_INT,
 		&g_program_args.buffer_size,
 		"<SIZE>",
-		"Frame Streams read buffer size, in bytes (default 262144)" },
+		"read buffer size, in bytes (default 262144)" },
 
-	{ 'c', "connections",
+	{ 'c', "maxconns",
 		ARGV_INT,
 		&g_program_args.count_connections,
 		"<COUNT>",
-		"Maximum number of concurrent connections allowed (default: 128)." },
+		"maximum concurrent connections allowed" },
 
 	{ 'w',	"write",
 		ARGV_CHAR_P,

--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -169,7 +169,7 @@ static argv_t g_args[] = {
 		ARGV_INT,
 		&g_program_args.buffer_size,
 		"<SIZE>",
-		"Frame streams read buffer size, in bytes (default 262144)" },
+		"Frame Streams read buffer size, in bytes (default 262144)" },
 
 	{ 'c', "connections",
 		ARGV_INT,


### PR DESCRIPTION
Add options for input buffer size and maximum concurrent connections to `fstrm_capture`.

The addition of TCP support makes these options more desirable for resource control purposes.

Closes issues #6 and #7.