### PR TITLE
Branches/program manpages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 EXTRA_DIST += COPYRIGHT
 EXTRA_DIST += LICENSE
 EXTRA_DIST += README.md
+EXTRA_DIST += man/fstrm_capture.1
+EXTRA_DIST += man/fstrm_replay.1
 
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
@@ -211,6 +213,8 @@ src_fstrm_capture_SOURCES = \
 src_fstrm_capture_LDADD = \
 	fstrm/libfstrm.la \
 	$(libevent_LIBS)
+
+man_MANS=man/fstrm_capture.1 man/fstrm_replay.1
 
 TESTS += t/program_tests/test_fstrm_dump.sh \
 	 t/program_tests/test_fstrm_replay.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,8 @@ src_fstrm_dump_LDADD = \
 
 bin_PROGRAMS += src/fstrm_replay
 src_fstrm_replay_SOURCES = \
-	src/fstrm_replay.c
+	src/fstrm_replay.c \
+	libmy/argv.c libmy/argv.h libmy/argv_loc.h
 src_fstrm_replay_LDADD = \
 	fstrm/libfstrm.la
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST += LICENSE
 EXTRA_DIST += README.md
 EXTRA_DIST += man/fstrm_capture.1
 EXTRA_DIST += man/fstrm_replay.1
+EXTRA_DIST += man/fstrm_dump.1
 
 AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
@@ -214,7 +215,7 @@ src_fstrm_capture_LDADD = \
 	fstrm/libfstrm.la \
 	$(libevent_LIBS)
 
-man_MANS=man/fstrm_capture.1 man/fstrm_replay.1
+man_MANS=man/fstrm_capture.1 man/fstrm_replay.1 man/fstrm_dump.1
 
 TESTS += t/program_tests/test_fstrm_dump.sh \
 	 t/program_tests/test_fstrm_replay.sh

--- a/man/fstrm_capture.1
+++ b/man/fstrm_capture.1
@@ -1,0 +1,68 @@
+.TH fstrm_capture 1
+
+.SH NAME
+
+fstrm_capture \- Receive and save Frame Streams data from a socket.
+
+.SH SYNOPSIS
+
+.B fstrm_capture -t \fIcontent-type\fB -w \fIfilename\fB
+.br
+.B "	[ -u \fIsocket-path\fB ] [ -a \fIIP\fB -p \fIport\fB ]"
+.br
+.B "	[ -s \fIseconds\fB ] [ --gmtime ] [ --localtime ]"
+
+.SH DESCRIPTION
+
+.B fstrm_capture
+listens on a UNIX domain or TCP socket, receives Frame Streams data,
+and writes the data to a file.
+
+.SH OPTIONS
+
+.TP
+.B -w \fIfilename\fB
+Write data to the file \fIfilename\fR.
+
+.TP
+.B -t \fIcontent-type\fB
+Specify the \fIcontent-type\fR to receive from the socket and write
+to the output \fIfilename\fR.
+
+.TP
+.B -u \fIsocket-path\fB
+Listen on \fIsocket-path\fR to receive Frame Streams data. Only one of
+\fB-u\fR or \fB-a\fR may be given.
+
+.TP
+.B -a \fIIP\fB
+Listen on address \fIIP\fR to receive Frame Streams data. Only one of
+\fB-u\fR or \fB-a\fR may be given. Use of \fB-a\fR requires a port
+given with \fB-p\fR.
+
+.TP
+.B -p \fIport\fB
+If \fB-a\fR is given, listen on TCP port \fIport\fR to receive Frame
+Streams data.
+
+.TP
+.B -s \fIinterval\fB
+Rotate output file every \fIinterval\fR seconds. Requires specifying
+either the \fB--gmtime\fR or \fB--localtime\fR options. If given,
+the filename is processed with \fIstrftime()\fR before opening the
+output file, using either the system local time zone (if \fB--localtime\fR
+is given) or GMT (if \fB--gmtime\fR is given).
+
+.SH EXAMPLES
+
+Receive dnstap data and save to hourly rotating files
+
+.nf
+	fstrm_capture -t protobuf:dnstap.Dnstap \\
+		-u /var/run/named/dnstap.sock -s 3600 \\
+		-w /var/log/dnstap/dnstap-%F-%T.fstrm
+.fi
+
+.SH SEE ALSO
+
+.B strftime(3)

--- a/man/fstrm_dump.1
+++ b/man/fstrm_dump.1
@@ -1,0 +1,46 @@
+.TH fstrm_dump 1
+
+.SH NAME
+
+fstrm_dump \- Display metadata and contents of Frame Streams file.
+
+.SH SYNOPSIS
+
+.B fstrm_dump \fIinput-file\fB [ \fIoutput-file\fB]
+
+.SH DESCRIPTION
+
+.B fstrm_dump
+opens
+.I input-file
+and prints its framing metadata to \fIstderr\fR and frame data to \fIstdout\fR.
+
+Frame data is printed as a single line quoted string with non-printable
+characters replaced by backslash-prefixed hex escape sequences. For example,
+a frame containing "Hello, world\\n" would have its data printed as:
+
+	 "Hello, world\\x0a"
+
+The only framing metadata expected in a Frame Streams file are the
+Start frame with a content type field, the data frame lengths, and
+the stop frame. These are printed, respectively, as:
+
+	FSTRM_CONTROL_START
+
+	FSTRM_CONTROL_FIELD_CONTENT_TYPE (\fIN\fR bytes).
+.br
+	 "\fIcontent-type\fR"
+
+	Data frame (\fIN\fR) bytes.
+
+	FSTRM_CONTROL_STOP.
+
+If
+.B fstrm_dump
+is given the second
+.I output-file
+parameter, the data is written to
+.I output-file
+as it is printed. This is mainly useful for regression testing of the
+.I fstrm_file_writer
+code.

--- a/man/fstrm_replay.1
+++ b/man/fstrm_replay.1
@@ -1,0 +1,59 @@
+.TH fstrm_replay 1
+
+.SH NAME
+
+fstrm_replay \- Replay saved Frame Streams data to a socket connection.
+
+.SH SYNOPSIS
+
+.B fstrm_replay -t \fIcontent-type\fB -r \fIfile\fB [ -r \fIfile\fB ... ]
+.br
+.B "	[ -u \fIsocket-path\fB ] [ -a \fIIP\fB -p \fIport\fB ]"
+
+.SH DESCRIPTION
+
+.B fstrm_replay
+connects to a Frame Streams receive on either the given UNIX domain
+\fIsocket-path\fR or TCP \fIaddress\fR and \fIport\fR, then reads
+and sends data of the supplied \fIcontent-type\fR from the given
+\fIfiles\fR.
+
+.SH OPTIONS
+
+.TP
+.B -t \fIcontent-type\fB
+Specify the \fIcontent-type\fR to read from files and send to the
+Frame Streams socket. Files whose content-type differs are skipped.
+If the socket server does not accept the \fIcontent-type\fR,
+fIfstrm_replay\fR will fail.
+
+.TP
+.B -r \fIfile\fB
+Read data from \fIfile\fR. Multiple files can be given with multiple
+\fB-r\fR options. Files which cannot be opened, or do not contain valid
+Frame Streams data will be skipped.
+
+.TP
+.B -u \fIsocket-path\fB
+Connect to \fIsocket-path\fR to write Frame Streams data. Only one of
+\fB-u\fR or \fB-a\fR may be given.
+
+.TP
+.B -a \fIIP\fB
+Connect to address \fIIP\fR to write Frame Streams data. Only one of
+\fB-u\fR or \fB-a\fR may be given. Use of \fB-a\fR requires a port
+given with \fB-p\fR.
+
+.TP
+.B -p \fIport\fB
+If \fB-a\fR is given, use TCP port \fIport\fR to write Frame Streams
+data.
+
+.SH EXAMPLES
+
+Replay dnstap data over UNIX domain socket:
+
+.nf
+	fstrm_replay -t protobuf:dnstap.Dnstap \\
+		-u /var/run/named/dnstap.sock -r dnstap-log.fstrm
+.fi

--- a/t/program_tests/test_fstrm_replay.sh.in
+++ b/t/program_tests/test_fstrm_replay.sh.in
@@ -12,11 +12,12 @@ output=$(mktemp)
 sockpath=$(mktemp)
 
 test="fstrm_replay unix socket"
-$exedir/fstrm_capture -u $sockpath -w $output -t test:hello &
+args="-t test:hello -u $sockpath"
+$exedir/fstrm_capture -w $output $args &
 cappid=$!
 sleep 1
 
-if $exedir/fstrm_replay unix $sockpath $input; then
+if $exedir/fstrm_replay -r $input $args; then
 	kill $cappid
 	wait $cappid
 	if cmp $input $output; then
@@ -35,11 +36,12 @@ rm -f $output
 output=$(mktemp)
 
 test="fstrm_replay tcp socket"
-$exedir/fstrm_capture -a 127.0.0.1 -p 15532 -w $output -t test:hello &
+args="-a 127.0.0.1 -p 15532 -t test:hello"
+$exedir/fstrm_capture -w $output $args &
 cappid=$!
 sleep 1
 
-if $exedir/fstrm_replay tcp 127.0.0.1:15532 $input; then
+if $exedir/fstrm_replay -r $input $args; then
 	kill $cappid
 	wait $cappid
 	if cmp $input $output; then


### PR DESCRIPTION
Flesh out `fstrm_replay` to take similar options to `fstrm_capture`, as the two programs are largely complementary.

Add man page for `fstrm_replay`, as well as `fstrm_capture` (Issue #30) and `fstrm_dump` (Issue #29).