### PR TITLE
Include netinet/in.h and sys/socket.h 

### DIFF
--- a/src/fstrm_replay.c
+++ b/src/fstrm_replay.c
@@ -15,6 +15,8 @@
  */
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <sys/uio.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
To get struct sockaddr_in and the AF_* defines respectively.  Fixes compile on OpenBSD and Posix requires these includes as well.