### PR TITLE
Leave room also for the terminating 0 character.

### DIFF
--- a/libmy/argv.c
+++ b/libmy/argv.c
@@ -482,7 +482,7 @@ static	int	expand_buf(const void *buf, const int buf_size,
       if (out_p + 2 >= max_p) {
 	break;
       }
-      LOC_SNPRINTF(SNP_ARG(out_p, 2), "\\%c", *(spec_p - 1));
+      LOC_SNPRINTF(SNP_ARG(out_p, 3), "\\%c", *(spec_p - 1));
       out_p += 2;
       continue;
     }
@@ -499,7 +499,7 @@ static	int	expand_buf(const void *buf, const int buf_size,
       if (out_p + 4 >= max_p) {
 	break;
       }
-      LOC_SNPRINTF(SNP_ARG(out_p, 4), "\\%03o", *buf_p);
+      LOC_SNPRINTF(SNP_ARG(out_p, 5), "\\%03o", *buf_p);
       out_p += 4;
     }
   }


### PR DESCRIPTION
This rids us of the warnings from gcc 7.4.0 (and 8.1)
related to the size of the output buffer and the given format.
This should fix issue #57 
