### PR TITLE
fstrm_capture: Ignore SIGPIPE

### DIFF
--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -1201,6 +1201,10 @@ setup_signals(void)
 	if (sigaction(SIGINT, &sa, NULL) != 0)
 		return false;
 
+	sa.sa_handler = SIG_IGN;
+	if (sigaction(SIGPIPE, &sa, NULL) != 0)
+		return false;
+
 	/* Success. */
 	return true;
 }


### PR DESCRIPTION
Some Frame Streams implementations send FSTRM_CONTROL_STOP to fstrm_capture without waiting to receive fstrm_capture's subsequent FSTRM_CONTROL_FINISH. This can cause fstrm_capture to abruptly exit due to an unhandled SIGPIPE signal, for instance if fstrm_capture is not running under systemd where IgnoreSIGPIPE= defaults to true.

This behavior was reported by a user on the unbound-users mailing list:
https://lists.nlnetlabs.nl/pipermail/unbound-users/2020-December/007141.html

This commit makes fstrm_capture ignore SIGPIPE, which will cause the interrupted connections to generate an EPIPE instead, which will be logged by cb_close_conn(). Perhaps it's also worthwhile to suppress the logging of EPIPE (or lower the verbosity from CONN_CRITICAL) since it now occurs normally in recent versions of Unbound, but I haven't done so in this commit.

This matches the behavior in libfstrm which ignores SIGPIPE in its I/O thread.