### PR TITLE
Release 0.6.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+fstrm (0.6.1)
+
+  * fstrm_capture: ignore SIGPIPE, which will cause the
+    interrupted connections to generate an EPIPE instead.
+
+  * Fix truncation in snprintf calls in argument processing.
+
+  * fstrm_capture: Fix output printf format.
+
 fstrm (0.6.0)
 
   * fstrm_capture: Perform output file rotation when a SIGUSR1 signal

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(2.64)
 
 AC_INIT([fstrm],
-        [0.6.0],
+        [0.6.1],
         [https://github.com/farsightsec/fstrm/issues],
         [fstrm],
         [https://github.com/farsightsec/fstrm])

--- a/libmy/argv.c
+++ b/libmy/argv.c
@@ -479,11 +479,11 @@ static	int	expand_buf(const void *buf, const int buf_size,
     
     /* did we find one? */
     if (*(spec_p - 1) != '\0') {
-      if (out_p + 2 >= max_p) {
+      if (out_p + 3 >= max_p) { /* make sure that snprintf has room to terminate its output */
 	break;
       }
-      LOC_SNPRINTF(SNP_ARG(out_p, 2), "\\%c", *(spec_p - 1));
-      out_p += 2;
+      LOC_SNPRINTF(SNP_ARG(out_p, 3), "\\%c", *(spec_p - 1)); /* outputing a backslash, a char, and a nul */
+      out_p += 2; /* don't include the nul in the final length */
       continue;
     }
     
@@ -496,10 +496,10 @@ static	int	expand_buf(const void *buf, const int buf_size,
       out_p += 1;
     }
     else {
-      if (out_p + 4 >= max_p) {
+      if (out_p + 5 >= max_p) {
 	break;
       }
-      LOC_SNPRINTF(SNP_ARG(out_p, 4), "\\%03o", *buf_p);
+      LOC_SNPRINTF(SNP_ARG(out_p, 5), "\\%03o", *buf_p); /* outputing a backslash, three digits, and a nul */
       out_p += 4;
     }
   }

--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -998,7 +998,7 @@ can_read_full_frame(struct conn *conn)
 			 conn->len_buf, conn->len_frame_total);
 		if (conn->len_frame_total > conn->ctx->capture_highwater) {
 			conn_log(CONN_WARNING, conn,
-				"Skipping %zd byte message (%zd buffer)",
+				"Skipping %u byte message (%zd buffer)",
 				conn->len_frame_total,
 				conn->ctx->capture_highwater);
 			conn->bytes_skip = conn->len_frame_total;

--- a/src/fstrm_capture.c
+++ b/src/fstrm_capture.c
@@ -1201,6 +1201,10 @@ setup_signals(void)
 	if (sigaction(SIGINT, &sa, NULL) != 0)
 		return false;
 
+	sa.sa_handler = SIG_IGN;
+	if (sigaction(SIGPIPE, &sa, NULL) != 0)
+		return false;
+
 	/* Success. */
 	return true;
 }


### PR DESCRIPTION
This release contains two changes to the fstrm_capture utility:
  * Fix snprintf truncation in command line argument handling
  * Ignore SIGPIPE for robustness when client prematurely closes its connection