### PR TITLE
Set timeout for sending and receiving on UNIX/TCP socket

### DIFF
--- a/fstrm/tcp_writer.c
+++ b/fstrm/tcp_writer.c
@@ -129,6 +129,25 @@ fstrm__tcp_writer_op_open(void *obj)
 	}
 #endif
 
+#if defined(SO_RCVTIMEO) || defined(SO_SNDTIMEO)
+	static const struct timeval timeout = {
+		.tv_sec = 1,
+		.tv_usec = 0
+	};
+#if defined(SO_RCVTIMEO)
+	if (setsockopt(w->fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+#endif
+#if defined(SO_SNDTIMEO)
+	if (setsockopt(w->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+#endif
+#endif
+
 	/* Connect the TCP socket. */
 	if (connect(w->fd, (struct sockaddr *) &w->ss, w->ss_len) < 0) {
 		close(w->fd);

--- a/fstrm/unix_writer.c
+++ b/fstrm/unix_writer.c
@@ -115,6 +115,25 @@ fstrm__unix_writer_op_open(void *obj)
 	}
 #endif
 
+#if defined(SO_RCVTIMEO) || defined(SO_SNDTIMEO)
+	static const struct timeval timeout = {
+		.tv_sec = 1,
+		.tv_usec = 0
+	};
+#if defined(SO_RCVTIMEO)
+	if (setsockopt(w->fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+#endif
+#if defined(SO_SNDTIMEO)
+	if (setsockopt(w->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+		close(w->fd);
+		return fstrm_res_failure;
+	}
+#endif
+#endif
+
 	/* Connect the AF_UNIX socket. */
 	if (connect(w->fd, (struct sockaddr *) &w->sa, sizeof(w->sa)) < 0) {
 		close(w->fd);


### PR DESCRIPTION
Set timeout for sending and receiving on UNIX/TCP socket to ensure that the io thread does not block when destroyed.

Fixes #69 